### PR TITLE
Fix version of redis package.

### DIFF
--- a/src/Microsoft.Framework.Cache.Redis/project.json
+++ b/src/Microsoft.Framework.Cache.Redis/project.json
@@ -1,4 +1,5 @@
 ﻿{
+  "version": "1.0.0-*",
   "dependencies": {
     "Microsoft.Framework.Cache.Distributed": "1.0.0-*",
     "StackExchange.Redis": "1.0.333"


### PR DESCRIPTION
The redis package is currently building as 1.0.0, when it should be 1.0.0-beta1-*.
