### PR TITLE
Moving IExpiration trigger into a new namespace

### DIFF
--- a/src/Microsoft.Framework.Cache.Memory/CacheSetContext.cs
+++ b/src/Microsoft.Framework.Cache.Memory/CacheSetContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Framework.Expiration.Interfaces;
 
 namespace Microsoft.Framework.Cache.Memory
 {

--- a/src/Microsoft.Framework.Cache.Memory/CancellationTokenTrigger.cs
+++ b/src/Microsoft.Framework.Cache.Memory/CancellationTokenTrigger.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Microsoft.Framework.Expiration.Interfaces;
 
 namespace Microsoft.Framework.Cache.Memory
 {

--- a/src/Microsoft.Framework.Cache.Memory/EntryLink.cs
+++ b/src/Microsoft.Framework.Cache.Memory/EntryLink.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Framework.Expiration.Interfaces;
 
 namespace Microsoft.Framework.Cache.Memory
 {

--- a/src/Microsoft.Framework.Cache.Memory/ICacheSetContext.cs
+++ b/src/Microsoft.Framework.Cache.Memory/ICacheSetContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Framework.Runtime;
+using Microsoft.Framework.Expiration.Interfaces;
 
 namespace Microsoft.Framework.Cache.Memory
 {

--- a/src/Microsoft.Framework.Cache.Memory/IEntryLink.cs
+++ b/src/Microsoft.Framework.Cache.Memory/IEntryLink.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Framework.Runtime;
+using Microsoft.Framework.Expiration.Interfaces;
 
 namespace Microsoft.Framework.Cache.Memory
 {

--- a/src/Microsoft.Framework.Cache.Memory/IExpirationTrigger.cs
+++ b/src/Microsoft.Framework.Cache.Memory/IExpirationTrigger.cs
@@ -4,7 +4,7 @@
 using System;
 using Microsoft.Framework.Runtime;
 
-namespace Microsoft.Framework.Cache.Memory
+namespace Microsoft.Framework.Expiration.Interfaces
 {
     [AssemblyNeutral]
     public interface IExpirationTrigger

--- a/test/Microsoft.Framework.Cache.Memory.Tests/Infrastructure/TestTrigger.cs
+++ b/test/Microsoft.Framework.Cache.Memory.Tests/Infrastructure/TestTrigger.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Framework.Expiration.Interfaces;
 
 namespace Microsoft.Framework.Cache.Memory.Infrastructure
 {


### PR DESCRIPTION
While refactoring the IFileSystem, IExpirationTrigger was moved to a new namespace. So moving this namespace as well.

Related PR: https://github.com/aspnet/FileSystem/pull/20/files

@lodejard @Tratcher @pranavkm 
