### PR TITLE
Changed namespace of IExpirationTrigger to Microsoft.Framework.Caching

### DIFF
--- a/src/Microsoft.Framework.Caching.Abstractions/ICacheSetContext.cs
+++ b/src/Microsoft.Framework.Caching.Abstractions/ICacheSetContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Framework.Expiration.Interfaces;
 
 namespace Microsoft.Framework.Caching.Memory
 {

--- a/src/Microsoft.Framework.Caching.Abstractions/IEntryLink.cs
+++ b/src/Microsoft.Framework.Caching.Abstractions/IEntryLink.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Framework.Expiration.Interfaces;
 
 namespace Microsoft.Framework.Caching.Memory
 {

--- a/src/Microsoft.Framework.Caching.Abstractions/IExpirationTrigger.cs
+++ b/src/Microsoft.Framework.Caching.Abstractions/IExpirationTrigger.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Microsoft.Framework.Expiration.Interfaces
+namespace Microsoft.Framework.Caching
 {
     public interface IExpirationTrigger
     {

--- a/src/Microsoft.Framework.Caching.Memory/CacheSetContext.cs
+++ b/src/Microsoft.Framework.Caching.Memory/CacheSetContext.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Framework.Expiration.Interfaces;
 
 namespace Microsoft.Framework.Caching.Memory
 {

--- a/src/Microsoft.Framework.Caching.Memory/CancellationTokenTrigger.cs
+++ b/src/Microsoft.Framework.Caching.Memory/CancellationTokenTrigger.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading;
-using Microsoft.Framework.Expiration.Interfaces;
 
 namespace Microsoft.Framework.Caching.Memory
 {

--- a/src/Microsoft.Framework.Caching.Memory/EntryLink.cs
+++ b/src/Microsoft.Framework.Caching.Memory/EntryLink.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Framework.Expiration.Interfaces;
 
 namespace Microsoft.Framework.Caching.Memory
 {

--- a/test/Microsoft.Framework.Caching.Memory.Tests/Infrastructure/TestTrigger.cs
+++ b/test/Microsoft.Framework.Caching.Memory.Tests/Infrastructure/TestTrigger.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Framework.Expiration.Interfaces;
 
 namespace Microsoft.Framework.Caching.Memory.Infrastructure
 {


### PR DESCRIPTION
This api seems to be used in repos: Caching, Mvc, FileSystem and StaticFiles

https://github.com/search?utf8=%E2%9C%93&q=user%3Aaspnet+IExpirationTrigger&type=Code&ref=searchresults

I have made corresponding changes in other repos and did a local build against this change. Will push them after this PR is pushed.

@Eilon @muratg @Tratcher 