### PR TITLE
Using 'nameof' operator instead of magic strings

### DIFF
--- a/src/Microsoft.Framework.Caching.Memory/CacheSetContext.cs
+++ b/src/Microsoft.Framework.Caching.Memory/CacheSetContext.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Framework.Caching.Memory
         {
             if (relative <= TimeSpan.Zero)
             {
-                throw new ArgumentOutOfRangeException("relative", relative, "The relative expiration value must be positive.");
+                throw new ArgumentOutOfRangeException(nameof(relative), relative, "The relative expiration value must be positive.");
             }
             SetAbsoluteExpiration(CreationTime + relative);
         }
@@ -59,7 +59,7 @@ namespace Microsoft.Framework.Caching.Memory
         {
             if (absolute <= CreationTime)
             {
-                throw new ArgumentOutOfRangeException("absolute", absolute, "The absolute expiration value must be in the future.");
+                throw new ArgumentOutOfRangeException(nameof(absolute), absolute, "The absolute expiration value must be in the future.");
             }
             if (!AbsoluteExpiration.HasValue)
             {
@@ -75,7 +75,7 @@ namespace Microsoft.Framework.Caching.Memory
         {
             if (offset <= TimeSpan.Zero)
             {
-                throw new ArgumentOutOfRangeException("offset", offset, "The sliding expiration value must be positive.");
+                throw new ArgumentOutOfRangeException(nameof(offset), offset, "The sliding expiration value must be positive.");
             }
             SlidingExpiration = offset;
         }

--- a/src/Microsoft.Framework.Caching.Redis/CacheContext.cs
+++ b/src/Microsoft.Framework.Caching.Redis/CacheContext.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Framework.Caching.Redis
         {
             if (relative <= TimeSpan.Zero)
             {
-                throw new ArgumentOutOfRangeException("relative", relative, "The relative expiration value must be positive.");
+                throw new ArgumentOutOfRangeException(nameof(relative), relative, "The relative expiration value must be positive.");
             }
             AbsoluteExpiration = CreationTime + relative;
         }
@@ -49,7 +49,7 @@ namespace Microsoft.Framework.Caching.Redis
         {
             if (absolute <= CreationTime)
             {
-                throw new ArgumentOutOfRangeException("absolute", absolute, "The absolute expiration value must be in the future.");
+                throw new ArgumentOutOfRangeException(nameof(absolute), absolute, "The absolute expiration value must be in the future.");
             }
             AbsoluteExpiration = absolute.ToUniversalTime();
         }
@@ -58,7 +58,7 @@ namespace Microsoft.Framework.Caching.Redis
         {
             if (offset <= TimeSpan.Zero)
             {
-                throw new ArgumentOutOfRangeException("offset", offset, "The sliding expiration value must be positive.");
+                throw new ArgumentOutOfRangeException(nameof(offset), offset, "The sliding expiration value must be positive.");
             }
             SlidingExpiration = offset;
         }


### PR DESCRIPTION
Using the "nameof" operator instead of magic string will help us if the variable change in the future for whatever the reason