### PR TITLE
Remove System.Threading.ThreadPool dependency

### DIFF
--- a/src/Microsoft.Framework.Caching.Abstractions/project.json
+++ b/src/Microsoft.Framework.Caching.Abstractions/project.json
@@ -10,7 +10,6 @@
             "dependencies": {
                 "System.Collections": "4.0.10-beta-*",
                 "System.Threading": "4.0.10-beta-*",
-                "System.Threading.ThreadPool": "4.0.10-beta-*",
                 "System.Threading.Tasks": "4.0.10-beta-*"
             }
         }

--- a/src/Microsoft.Framework.Caching.Memory/CacheEntry.cs
+++ b/src/Microsoft.Framework.Caching.Memory/CacheEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Framework.Caching.Memory
 {
@@ -151,7 +151,7 @@ namespace Microsoft.Framework.Caching.Memory
             PostEvictionCallbacks = null;
             if (callbacks != null)
             {
-                ThreadPool.QueueUserWorkItem(InvokeCallbacks, callbacks);
+                Task.Factory.StartNew(InvokeCallbacks, callbacks);
             }
         }
 

--- a/src/Microsoft.Framework.Caching.Memory/MemoryCache.cs
+++ b/src/Microsoft.Framework.Caching.Memory/MemoryCache.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Framework.Internal;
 using Microsoft.Framework.OptionsModel;
 
@@ -290,11 +291,11 @@ namespace Microsoft.Framework.Caching.Memory
             if (_expirationScanFrequency < now - _lastExpirationScan)
             {
                 _lastExpirationScan = now;
-                ThreadPool.QueueUserWorkItem(ScanForExpiredItems);
+                Task.Factory.StartNew(ScanForExpiredItems);
             }
         }
 
-        private void ScanForExpiredItems(object state)
+        private void ScanForExpiredItems()
         {
             List<CacheEntry> expiredEntries = new List<CacheEntry>();
 

--- a/src/Microsoft.Framework.Caching.Memory/project.json
+++ b/src/Microsoft.Framework.Caching.Memory/project.json
@@ -17,8 +17,7 @@
         "dotnet": {
             "dependencies": {
                 "System.Linq": "4.0.0-*",
-                "System.Threading": "4.0.10-beta-*",
-                "System.Threading.ThreadPool": "4.0.10-beta-*"
+                "System.Threading": "4.0.10-beta-*"
             }
         }
     }


### PR DESCRIPTION
It prevented the package from installing on UWP projects.

@rowanmiller @natemcmaster 