### PR TITLE
IDistributedCache Extension Methods

### DIFF
--- a/src/Microsoft.Framework.Caching.Abstractions/DistributedCacheExtensions.cs
+++ b/src/Microsoft.Framework.Caching.Abstractions/DistributedCacheExtensions.cs
@@ -1,8 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.IO;
+#if DNX451
+using System.Runtime.Serialization.Formatters.Binary;
+#endif
 using System.Threading.Tasks;
 using Microsoft.Framework.Internal;
+using Newtonsoft.Json;
 
 namespace Microsoft.Framework.Caching.Distributed
 {
@@ -17,5 +22,305 @@ namespace Microsoft.Framework.Caching.Distributed
         {
             return cache.SetAsync(key, value, new DistributedCacheEntryOptions());
         }
+
+        #region BinaryReader & BinaryWriter
+
+        public static async Task<bool> GetBooleanAsync(this IDistributedCache cache, string key)
+        {
+            byte[] bytes = await cache.GetAsync(key);
+            using (MemoryStream memoryStream = new MemoryStream(bytes))
+            {
+                BinaryReader binaryReader = new BinaryReader(memoryStream);
+                return binaryReader.ReadBoolean();
+            }
+        }
+
+        public static async Task<char> GetCharAsync(this IDistributedCache cache, [NotNull] string key)
+        {
+            byte[] bytes = await cache.GetAsync(key);
+            using (MemoryStream memoryStream = new MemoryStream(bytes))
+            {
+                BinaryReader binaryReader = new BinaryReader(memoryStream);
+                return binaryReader.ReadChar();
+            }
+        }
+
+        public static async Task<decimal> GetDecimalAsync(this IDistributedCache cache, [NotNull] string key)
+        {
+            byte[] bytes = await cache.GetAsync(key);
+            using (MemoryStream memoryStream = new MemoryStream(bytes))
+            {
+                BinaryReader binaryReader = new BinaryReader(memoryStream);
+                return binaryReader.ReadDecimal();
+            }
+        }
+
+        public static async Task<double> GetDoubleAsync(this IDistributedCache cache, [NotNull] string key)
+        {
+            byte[] bytes = await cache.GetAsync(key);
+            using (MemoryStream memoryStream = new MemoryStream(bytes))
+            {
+                BinaryReader binaryReader = new BinaryReader(memoryStream);
+                return binaryReader.ReadDouble();
+            }
+        }
+
+        public static async Task<short> GetShortAsync(this IDistributedCache cache, [NotNull] string key)
+        {
+            byte[] bytes = await cache.GetAsync(key);
+            using (MemoryStream memoryStream = new MemoryStream(bytes))
+            {
+                BinaryReader binaryReader = new BinaryReader(memoryStream);
+                return binaryReader.ReadInt16();
+            }
+        }
+
+        public static async Task<int> GetIntAsync(this IDistributedCache cache, [NotNull] string key)
+        {
+            byte[] bytes = await cache.GetAsync(key);
+            using (MemoryStream memoryStream = new MemoryStream(bytes))
+            {
+                BinaryReader binaryReader = new BinaryReader(memoryStream);
+                return binaryReader.ReadInt32();
+            }
+        }
+
+        public static async Task<long> GetLongAsync(this IDistributedCache cache, [NotNull] string key)
+        {
+            byte[] bytes = await cache.GetAsync(key);
+            using (MemoryStream memoryStream = new MemoryStream(bytes))
+            {
+                BinaryReader binaryReader = new BinaryReader(memoryStream);
+                return binaryReader.ReadInt64();
+            }
+        }
+
+        public static async Task<float> GetFloatAsync(this IDistributedCache cache, [NotNull] string key)
+        {
+            byte[] bytes = await cache.GetAsync(key);
+            using (MemoryStream memoryStream = new MemoryStream(bytes))
+            {
+                BinaryReader binaryReader = new BinaryReader(memoryStream);
+                return binaryReader.ReadSingle();
+            }
+        }
+
+        public static async Task<string> GetStringAsync(this IDistributedCache cache, [NotNull] string key)
+        {
+            byte[] bytes = await cache.GetAsync(key);
+            using (MemoryStream memoryStream = new MemoryStream(bytes))
+            {
+                BinaryReader binaryReader = new BinaryReader(memoryStream);
+                return binaryReader.ReadString();
+            }
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, bool value)
+        {
+            return SetAsync(cache, key, value, new DistributedCacheEntryOptions());
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, bool value, DistributedCacheEntryOptions options)
+        {
+            byte[] bytes;
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                BinaryWriter binaryWriter = new BinaryWriter(memoryStream);
+                binaryWriter.Write(value);
+                bytes = memoryStream.ToArray();
+            }
+            return cache.SetAsync(key, bytes, options);
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, char value)
+        {
+            return SetAsync(cache, key, value, new DistributedCacheEntryOptions());
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, char value, DistributedCacheEntryOptions options)
+        {
+            byte[] bytes;
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                BinaryWriter binaryWriter = new BinaryWriter(memoryStream);
+                binaryWriter.Write(value);
+                bytes = memoryStream.ToArray();
+            }
+            return cache.SetAsync(key, bytes, options);
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, decimal value)
+        {
+            return SetAsync(cache, key, value, new DistributedCacheEntryOptions());
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, decimal value, DistributedCacheEntryOptions options)
+        {
+            byte[] bytes;
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                BinaryWriter binaryWriter = new BinaryWriter(memoryStream);
+                binaryWriter.Write(value);
+                bytes = memoryStream.ToArray();
+            }
+            return cache.SetAsync(key, bytes, options);
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, double value)
+        {
+            return SetAsync(cache, key, value, new DistributedCacheEntryOptions());
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, double value, DistributedCacheEntryOptions options)
+        {
+            byte[] bytes;
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                BinaryWriter binaryWriter = new BinaryWriter(memoryStream);
+                binaryWriter.Write(value);
+                bytes = memoryStream.ToArray();
+            }
+            return cache.SetAsync(key, bytes, options);
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, short value)
+        {
+            return SetAsync(cache, key, value, new DistributedCacheEntryOptions());
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, short value, DistributedCacheEntryOptions options)
+        {
+            byte[] bytes;
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                BinaryWriter binaryWriter = new BinaryWriter(memoryStream);
+                binaryWriter.Write(value);
+                bytes = memoryStream.ToArray();
+            }
+            return cache.SetAsync(key, bytes, options);
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, int value)
+        {
+            return SetAsync(cache, key, value, new DistributedCacheEntryOptions());
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, int value, DistributedCacheEntryOptions options)
+        {
+            byte[] bytes;
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                BinaryWriter binaryWriter = new BinaryWriter(memoryStream);
+                binaryWriter.Write(value);
+                bytes = memoryStream.ToArray();
+            }
+            return cache.SetAsync(key, bytes, options);
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, long value)
+        {
+            return SetAsync(cache, key, value, new DistributedCacheEntryOptions());
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, long value, DistributedCacheEntryOptions options)
+        {
+            byte[] bytes;
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                BinaryWriter binaryWriter = new BinaryWriter(memoryStream);
+                binaryWriter.Write(value);
+                bytes = memoryStream.ToArray();
+            }
+            return cache.SetAsync(key, bytes, options);
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, float value)
+        {
+            return SetAsync(cache, key, value, new DistributedCacheEntryOptions());
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, float value, DistributedCacheEntryOptions options)
+        {
+            byte[] bytes;
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                BinaryWriter binaryWriter = new BinaryWriter(memoryStream);
+                binaryWriter.Write(value);
+                bytes = memoryStream.ToArray();
+            }
+            return cache.SetAsync(key, bytes, options);
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, string value)
+        {
+            return SetAsync(cache, key, value, new DistributedCacheEntryOptions());
+        }
+
+        public static Task SetAsync(this IDistributedCache cache, [NotNull] string key, string value, DistributedCacheEntryOptions options)
+        {
+            byte[] bytes;
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                BinaryWriter binaryWriter = new BinaryWriter(memoryStream);
+                binaryWriter.Write(value);
+                bytes = memoryStream.ToArray();
+            }
+            return cache.SetAsync(key, bytes, options);
+        }
+
+        #endregion
+
+        #region JSON
+
+        public static async Task<T> GetAsJsonAsync<T>(this IDistributedCache cache, [NotNull] string key)
+        {
+            string json = await GetStringAsync(cache, key);
+            return JsonConvert.DeserializeObject<T>(json);
+        }
+
+        public static Task SetAsJsonAsync<T>(this IDistributedCache cache, [NotNull] string key, T value)
+        {
+            return SetAsJsonAsync(cache, key, value, new DistributedCacheEntryOptions());
+        }
+
+        public static Task SetAsJsonAsync<T>(this IDistributedCache cache, [NotNull] string key, T value, DistributedCacheEntryOptions options)
+        {
+            string json = JsonConvert.SerializeObject(value, Formatting.None);
+            return SetAsync(cache, key, json, options);
+        }
+
+        #endregion
+
+        #region BinaryFormatter
+#if DNX451
+        public static async Task<T> GetAsync<T>(this IDistributedCache cache, [NotNull] string key)
+        {
+            byte[] bytes = await cache.GetAsync(key);
+            using (MemoryStream memoryStream = new MemoryStream(bytes))
+            {
+                BinaryFormatter binaryFormatter = new BinaryFormatter();
+                return (T)binaryFormatter.Deserialize(memoryStream);
+            }
+        }
+
+        public static Task SetAsync<T>(this IDistributedCache cache, [NotNull] string key, T value)
+        {
+            return SetAsync(cache, key, value, new DistributedCacheEntryOptions());
+        }
+
+        public static Task SetAsync<T>(this IDistributedCache cache, [NotNull] string key, T value, DistributedCacheEntryOptions options)
+        {
+            byte[] bytes;
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                BinaryFormatter binaryFormatter = new BinaryFormatter();
+                binaryFormatter.Serialize(memoryStream, value);
+                bytes = memoryStream.ToArray();
+            }
+
+            return cache.SetAsync(key, bytes, options);
+        }
+#endif
+        #endregion
     }
 }

--- a/src/Microsoft.Framework.Caching.Abstractions/project.json
+++ b/src/Microsoft.Framework.Caching.Abstractions/project.json
@@ -2,7 +2,7 @@
     "dependencies": {
       "Microsoft.Framework.NotNullAttribute.Sources": {
         "type": "build",
-        "version": "1.0.0-beta5"
+        "version": "1.0.0-*"
       },
       "Newtonsoft.Json": "6.0.6"
     },
@@ -12,12 +12,15 @@
         "dnx451": { },
         "dotnet": {
             "dependencies": {
-                "System.Collections": "4.0.10-beta-23019",
-                "System.Threading": "4.0.10-beta-23019",
-                "System.Threading.ThreadPool": "4.0.10-beta-23019",
-                "System.Threading.Tasks": "4.0.10-beta-23019"
+                "System.Collections": "4.0.10-beta-*",
+                "System.Threading": "4.0.10-beta-*",
+                "System.Threading.Tasks": "4.0.10-beta-*"
             }
         }
     },
-    "version": "1.0.0-beta5"
+    "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/aspnet/caching"
+    }
 }

--- a/src/Microsoft.Framework.Caching.Abstractions/project.json
+++ b/src/Microsoft.Framework.Caching.Abstractions/project.json
@@ -1,6 +1,10 @@
 {
     "dependencies": {
-        "Microsoft.Framework.NotNullAttribute.Sources": { "type": "build", "version": "1.0.0-*" }
+      "Microsoft.Framework.NotNullAttribute.Sources": {
+        "type": "build",
+        "version": "1.0.0-beta5"
+      },
+      "Newtonsoft.Json": "6.0.6"
     },
     "description": "ASP.NET 5 in memory cache abstractions.",
     "frameworks": {
@@ -8,15 +12,12 @@
         "dnx451": { },
         "dotnet": {
             "dependencies": {
-                "System.Collections": "4.0.10-beta-*",
-                "System.Threading": "4.0.10-beta-*",
-                "System.Threading.Tasks": "4.0.10-beta-*"
+                "System.Collections": "4.0.10-beta-23019",
+                "System.Threading": "4.0.10-beta-23019",
+                "System.Threading.ThreadPool": "4.0.10-beta-23019",
+                "System.Threading.Tasks": "4.0.10-beta-23019"
             }
         }
     },
-    "version": "1.0.0-*",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/aspnet/caching"
-    }
+    "version": "1.0.0-beta5"
 }


### PR DESCRIPTION
I have created three sets of extension methods for IDistributedCache.

1. based on BinaryReader & BinaryWriter. This gives us simple types like int and string.
2. Based on BinaryFormatter (Not available for DNX Core) but provides best performance. Caching is all about performance so it makes sense to use this. Is there a chance we could bring the BinaryFormatter to DNX Core?
3. Using JSON.NET Serializer with BinaryReader & BinaryWriter. This is a workaround for the BinaryFormatter not being available. This requires a dependency on NewtonSoft.Json. I chose to use version 6.0.6 because that is what is being used elsewhere in ASP.NET 5.

I hope to provoke a discussion about what we can do to make using
IDistributedCache easier.