### PR TITLE
[Fixes #67] Key for memory cache should be of type object instead of …

### DIFF
--- a/samples/MemoryCacheConcurencySample/Program.cs
+++ b/samples/MemoryCacheConcurencySample/Program.cs
@@ -45,7 +45,7 @@ namespace MemoryCacheSample
                 .RegisterPostEvictionCallback(AfterEvicted, state: null);
         }
 
-        private void AfterEvicted(string key, object value, EvictionReason reason, object state)
+        private void AfterEvicted(object key, object value, EvictionReason reason, object state)
         {
             Console.WriteLine("Evicted. Value: " + value + ", Reason: " + reason);
         }

--- a/src/Microsoft.Framework.Caching.Abstractions/IMemoryCache.cs
+++ b/src/Microsoft.Framework.Caching.Abstractions/IMemoryCache.cs
@@ -16,24 +16,24 @@ namespace Microsoft.Framework.Caching.Memory
         /// <summary>
         /// Create or overwrite an entry in the cache.
         /// </summary>
-        /// <param name="key">A string identifying the entry. This is case sensitive.</param>
+        /// <param name="key">An object identifying the entry.</param>
         /// <param name="value">The value to be cached.</param>
         /// <param name="options">The <see cref="MemoryCacheEntryOptions"/>.</param>
         /// <returns>The object that was cached.</returns>
-        object Set(string key, object value, MemoryCacheEntryOptions options);
+        object Set(object key, object value, MemoryCacheEntryOptions options);
 
         /// <summary>
         /// Gets the item associated with this key if present.
         /// </summary>
-        /// <param name="key">A string identifying the requested entry.</param>
+        /// <param name="key">An object identifying the requested entry.</param>
         /// <param name="value">The located value or null.</param>
         /// <returns>True if the key was found.</returns>
-        bool TryGetValue(string key, out object value);
+        bool TryGetValue(object key, out object value);
 
         /// <summary>
         /// Removes the object associated with the given key.
         /// </summary>
-        /// <param name="key">A string identifying the entry. This is case sensitive.</param>
-        void Remove(string key);
+        /// <param name="key">An object identifying the entry.</param>
+        void Remove(object key);
     }
 }

--- a/src/Microsoft.Framework.Caching.Abstractions/MemoryCacheExtensions.cs
+++ b/src/Microsoft.Framework.Caching.Abstractions/MemoryCacheExtensions.cs
@@ -5,21 +5,21 @@ namespace Microsoft.Framework.Caching.Memory
 {
     public static class CacheExtensions
     {
-        public static object Get(this IMemoryCache cache, string key)
+        public static object Get(this IMemoryCache cache, object key)
         {
             object value = null;
             cache.TryGetValue(key, out value);
             return value;
         }
 
-        public static TItem Get<TItem>(this IMemoryCache cache, string key)
+        public static TItem Get<TItem>(this IMemoryCache cache, object key)
         {
             TItem value;
             cache.TryGetValue<TItem>(key, out value);
             return value;
         }
 
-        public static bool TryGetValue<TItem>(this IMemoryCache cache, string key, out TItem value)
+        public static bool TryGetValue<TItem>(this IMemoryCache cache, object key, out TItem value)
         {
             object obj = null;
             if (cache.TryGetValue(key, out obj))
@@ -31,22 +31,22 @@ namespace Microsoft.Framework.Caching.Memory
             return false;
         }
 
-        public static object Set(this IMemoryCache cache, string key, object value)
+        public static object Set(this IMemoryCache cache, object key, object value)
         {
             return cache.Set(key, value, new MemoryCacheEntryOptions());
         }
 
-        public static object Set(this IMemoryCache cache, string key, object value, MemoryCacheEntryOptions options)
+        public static object Set(this IMemoryCache cache, object key, object value, MemoryCacheEntryOptions options)
         {
             return cache.Set(key, value, options);
         }
 
-        public static TItem Set<TItem>(this IMemoryCache cache, string key, TItem value)
+        public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value)
         {
             return (TItem)cache.Set(key, (object)value, new MemoryCacheEntryOptions());
         }
 
-        public static TItem Set<TItem>(this IMemoryCache cache, string key, TItem value, MemoryCacheEntryOptions options)
+        public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value, MemoryCacheEntryOptions options)
         {
             return (TItem)cache.Set(key, (object)value, options);
         }

--- a/src/Microsoft.Framework.Caching.Abstractions/PostEvictionDelegate.cs
+++ b/src/Microsoft.Framework.Caching.Abstractions/PostEvictionDelegate.cs
@@ -10,5 +10,5 @@ namespace Microsoft.Framework.Caching.Memory
     /// <param name="value"></param>
     /// <param name="reason">The <see cref="EvictionReason"/>.</param>
     /// <param name="state">The information that was passed when registering the callback.</param>
-    public delegate void PostEvictionDelegate(string key, object value, EvictionReason reason, object state);
+    public delegate void PostEvictionDelegate(object key, object value, EvictionReason reason, object state);
 }

--- a/src/Microsoft.Framework.Caching.Memory/CacheEntry.cs
+++ b/src/Microsoft.Framework.Caching.Memory/CacheEntry.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Framework.Caching.Memory
         private readonly DateTimeOffset? _absoluteExpiration;
 
         internal CacheEntry(
-            string key,
+            object key,
             object value,
             DateTimeOffset utcNow,
             DateTimeOffset? absoluteExpiration,
@@ -35,7 +35,7 @@ namespace Microsoft.Framework.Caching.Memory
 
         internal MemoryCacheEntryOptions Options { get; private set; }
 
-        internal string Key { get; private set; }
+        internal object Key { get; private set; }
 
         internal object Value { get; private set; }
 

--- a/src/Microsoft.Framework.Caching.Memory/MemoryCache.cs
+++ b/src/Microsoft.Framework.Caching.Memory/MemoryCache.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Framework.Caching.Memory
 {
     public class MemoryCache : IMemoryCache
     {
-        private readonly Dictionary<string, CacheEntry> _entries;
+        private readonly Dictionary<object, CacheEntry> _entries;
         private readonly ReaderWriterLockSlim _entryLock;
         private bool _disposed;
 
@@ -31,7 +31,7 @@ namespace Microsoft.Framework.Caching.Memory
         public MemoryCache([NotNull] IOptions<MemoryCacheOptions> optionsAccessor)
         {
             var options = optionsAccessor.Options;
-            _entries = new Dictionary<string, CacheEntry>(StringComparer.Ordinal);
+            _entries = new Dictionary<object, CacheEntry>();
             _entryLock = new ReaderWriterLockSlim();
             _entryExpirationNotification = EntryExpired;
             _clock = options.Clock ?? new SystemClock();
@@ -64,7 +64,7 @@ namespace Microsoft.Framework.Caching.Memory
             return EntryLinkHelpers.CreateLinkingScope();
         }
 
-        public object Set([NotNull] string key, object value, MemoryCacheEntryOptions cacheEntryOptions)
+        public object Set([NotNull] object key, object value, MemoryCacheEntryOptions cacheEntryOptions)
         {
             CheckDisposed();
             CacheEntry priorEntry = null;
@@ -147,7 +147,7 @@ namespace Microsoft.Framework.Caching.Memory
             return value;
         }
 
-        public bool TryGetValue([NotNull] string key, out object value)
+        public bool TryGetValue([NotNull] object key, out object value)
         {
             value = null;
             CacheEntry expiredEntry = null;
@@ -203,7 +203,7 @@ namespace Microsoft.Framework.Caching.Memory
             return found;
         }
 
-        public void Remove([NotNull] string key)
+        public void Remove([NotNull] object key)
         {
             CheckDisposed();
             CacheEntry entry;

--- a/test/Microsoft.Framework.Caching.Memory.Tests/CacheServiceExtensionsTests.cs
+++ b/test/Microsoft.Framework.Caching.Memory.Tests/CacheServiceExtensionsTests.cs
@@ -81,17 +81,17 @@ namespace Microsoft.Framework.Caching.Distributed
                 throw new NotImplementedException();
             }
 
-            public void Remove(string key)
+            public void Remove(object key)
             {
                 throw new NotImplementedException();
             }
 
-            public object Set(string key, object value, MemoryCacheEntryOptions cacheEntryOptions)
+            public object Set(object key, object value, MemoryCacheEntryOptions cacheEntryOptions)
             {
                 throw new NotImplementedException();
             }
 
-            public bool TryGetValue(string key, out object value)
+            public bool TryGetValue(object key, out object value)
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.Framework.Caching.Memory.Tests/MemoryCacheSetAndRemoveTests.cs
+++ b/test/Microsoft.Framework.Caching.Memory.Tests/MemoryCacheSetAndRemoveTests.cs
@@ -209,5 +209,29 @@ namespace Microsoft.Framework.Caching.Memory
             result = cache.Get(key);
             Assert.Same(obj2, result);
         }
+
+        [Fact]
+        public void SetGetAndRemoveWorks_WithNonStringKeys()
+        {
+            var cache = CreateCache();
+            var obj = new object();
+            var key = new Person { Id = 10, Name = "Mike" };
+
+            var result = cache.Set(key, obj);
+            Assert.Same(obj, result);
+
+            result = cache.Get(key);
+            Assert.Same(obj, result);
+
+            cache.Remove(key);
+            result = cache.Get(key);
+            Assert.Null(result);
+        }
+
+        private class Person
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
     }
 }


### PR DESCRIPTION
…string

@Tratcher 

@divega I guess you wanted to change the following area of code after this change
https://github.com/aspnet/EntityFramework/blob/dev/src/EntityFramework.Core/Query/CompiledQueryCache.cs#L166-L170