### PR TITLE
Use earliest compatible dependencies

### DIFF
--- a/src/Microsoft.Framework.Caching.Abstractions/project.json
+++ b/src/Microsoft.Framework.Caching.Abstractions/project.json
@@ -8,9 +8,9 @@
         "dnx451": { },
         "dotnet": {
             "dependencies": {
-                "System.Collections": "4.0.11-beta-*",
-                "System.Threading": "4.0.11-beta-*",
-                "System.Threading.Tasks": "4.0.11-beta-*"
+                "System.Collections": "4.0.0",
+                "System.Runtime": "4.0.0",
+                "System.Threading.Tasks": "4.0.0"
             }
         }
     },

--- a/src/Microsoft.Framework.Caching.Memory/project.json
+++ b/src/Microsoft.Framework.Caching.Memory/project.json
@@ -6,8 +6,8 @@
         "url": "https://github.com/aspnet/caching"
     },
     "dependencies": {
-        "Microsoft.Framework.DependencyInjection.Abstractions": "1.0.0-*",
         "Microsoft.Framework.Caching.Abstractions": "1.0.0-*",
+        "Microsoft.Framework.DependencyInjection.Abstractions": "1.0.0-*",
         "Microsoft.Framework.NotNullAttribute.Sources": { "type": "build", "version": "1.0.0-*" },
         "Microsoft.Framework.OptionsModel": "1.0.0-*"
     },
@@ -16,8 +16,13 @@
         "dnx451": { },
         "dotnet": {
             "dependencies": {
-                "System.Linq": "4.0.1-beta-*",
-                "System.Threading": "4.0.11-beta-*"
+                "System.Collections": "4.0.0",
+                "System.Diagnostics.Debug": "4.0.0",
+                "System.Linq": "4.0.0",
+                "System.Runtime": "4.0.0",
+                "System.Runtime.Extensions": "4.0.0",
+                "System.Threading": "4.0.10",
+                "System.Threading.Tasks": "4.0.0"
             }
         }
     }


### PR DESCRIPTION
Enables our packages to work on more platforms with more libraries

Note, `AsyncLocal<T>` is the only thing preventing this from working on win8+wp80+wpa81.