### PR TITLE
Clean up mention(s) of 'k' from source code

### DIFF
--- a/src/Microsoft.Framework.Caching.Memory/EntryLinkHelpers.cs
+++ b/src/Microsoft.Framework.Caching.Memory/EntryLinkHelpers.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Framework.Caching.Memory
             set { _contextLink.Value = value; }
         }
 #else
-        private const string ContextLinkDataName = "klr.host.EntryLinkHelpers.ContextLink";
+        private const string ContextLinkDataName = "EntryLinkHelpers.ContextLink";
 
         public static EntryLink ContextLink
         {


### PR DESCRIPTION
Fixes #56 

@kichalla @davidfowl 

FYI: I looked through everywhere keys are passed to `LocalGetData` and it seems fairly random as long as it's unique-ish.