### PR TITLE
Return IServiceCollection from builder methods so that additional calls can be chained

### DIFF
--- a/src/Microsoft.Extensions.Caching.Memory/MemoryCacheServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Caching.Memory/MemoryCacheServiceCollectionExtensions.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <see cref="IServiceCollection" />.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
-        public static void AddMemoryCache(this IServiceCollection services)
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection AddMemoryCache(this IServiceCollection services)
         {
             if (services == null)
             {
@@ -27,6 +28,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddOptions();
             services.TryAdd(ServiceDescriptor.Singleton<IMemoryCache, MemoryCache>());
+
+            return services;
         }
 
         /// <summary>
@@ -37,7 +40,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="setupAction">
         /// The <see cref="Action{MemoryCacheOptions}"/> to configure the provided <see cref="MemoryCacheOptions"/>.
         /// </param>
-        public static void AddMemoryCache(this IServiceCollection services, Action<MemoryCacheOptions> setupAction)
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection AddMemoryCache(this IServiceCollection services, Action<MemoryCacheOptions> setupAction)
         {
             if (services == null)
             {
@@ -51,6 +55,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddMemoryCache();
             services.Configure(setupAction);
+
+            return services;
         }
 
         /// <summary>
@@ -66,7 +72,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// multiple machines.
         /// </remarks>
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
-        public static void AddDistributedMemoryCache(this IServiceCollection services)
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection AddDistributedMemoryCache(this IServiceCollection services)
         {
             if (services == null)
             {
@@ -75,6 +82,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddMemoryCache();
             services.TryAdd(ServiceDescriptor.Transient<IDistributedCache, MemoryDistributedCache>());
+
+            return services;
         }
     }
 }

--- a/src/Microsoft.Extensions.Caching.Redis/RedisCacheServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Caching.Redis/RedisCacheServiceCollectionExtensions.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
         /// <param name="setupAction">An <see cref="Action{RedisCacheOptions}"/> to configure the provided
         /// <see cref="RedisCacheOptions"/>.</param>
-        public static void AddDistributedRedisCache(this IServiceCollection services, Action<RedisCacheOptions> setupAction)
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection AddDistributedRedisCache(this IServiceCollection services, Action<RedisCacheOptions> setupAction)
         {
             if (services == null)
             {
@@ -34,6 +35,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddOptions();
             services.Configure(setupAction);
             services.Add(ServiceDescriptor.Singleton<IDistributedCache, RedisCache>());
+
+            return services;
         }
     }
 }

--- a/src/Microsoft.Extensions.Caching.SqlServer/SqlServerCacheServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Caching.SqlServer/SqlServerCacheServiceCollectionExtensions.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
         /// <param name="setupAction">An <see cref="Action{SqlServerCacheOptions}"/> to configure the provided <see cref="SqlServerCacheOptions"/>.</param>
-        public static void AddDistributedSqlServerCache(this IServiceCollection services, Action<SqlServerCacheOptions> setupAction)
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection AddDistributedSqlServerCache(this IServiceCollection services, Action<SqlServerCacheOptions> setupAction)
         {
             if (services == null)
             {
@@ -33,6 +34,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddOptions();
             AddSqlServerCacheServices(services);
             services.Configure(setupAction);
+
+            return services;
         }
 
         // to enable unit testing

--- a/test/Microsoft.Extensions.Caching.Memory.Tests/CacheServiceExtensionsTests.cs
+++ b/test/Microsoft.Extensions.Caching.Memory.Tests/CacheServiceExtensionsTests.cs
@@ -70,6 +70,30 @@ namespace Microsoft.Extensions.Caching.Distributed
             Assert.IsType<TestDistributedCache>(serviceProvider.GetRequiredService<IDistributedCache>());
         }
 
+        [Fact]
+        public void AddMemoryCache_allows_chaining()
+        {
+            var services = new ServiceCollection();
+
+            Assert.Same(services, services.AddMemoryCache());
+        }
+
+        [Fact]
+        public void AddMemoryCache_with_action_allows_chaining()
+        {
+            var services = new ServiceCollection();
+
+            Assert.Same(services, services.AddMemoryCache(_ => { }));
+        }
+
+        [Fact]
+        public void AddDistributedMemoryCache_allows_chaining()
+        {
+            var services = new ServiceCollection();
+
+            Assert.Same(services, services.AddDistributedMemoryCache());
+        }
+
         private class TestMemoryCache : IMemoryCache
         {
             public IEntryLink CreateLinkingScope()

--- a/test/Microsoft.Extensions.Caching.Redis.Tests/CacheServiceExtensionsTests.cs
+++ b/test/Microsoft.Extensions.Caching.Redis.Tests/CacheServiceExtensionsTests.cs
@@ -49,5 +49,13 @@ namespace Microsoft.Extensions.Caching.Redis
             Assert.Equal(ServiceLifetime.Scoped, distributedCache.Lifetime);
             Assert.IsType<RedisCache>(serviceProvider.GetRequiredService<IDistributedCache>());
         }
+
+        [Fact]
+        public void AddDistributedRedisCache_allows_chaining()
+        {
+            var services = new ServiceCollection();
+
+            Assert.Same(services, services.AddDistributedRedisCache(_ => { }));
+        }
     }
 }

--- a/test/Microsoft.Extensions.Caching.SqlServer.Tests/SqlServerCacheServicesExtensionsTest.cs
+++ b/test/Microsoft.Extensions.Caching.SqlServer.Tests/SqlServerCacheServicesExtensionsTest.cs
@@ -54,5 +54,13 @@ namespace Microsoft.Extensions.Caching.SqlServer
             Assert.Equal(ServiceLifetime.Scoped, distributedCache.Lifetime);
             Assert.IsType<SqlServerCache>(serviceProvider.GetRequiredService<IDistributedCache>());
         }
+
+        [Fact]
+        public void AddDistributedSqlServerCache_allows_chaining()
+        {
+            var services = new ServiceCollection();
+
+            Assert.Same(services, services.AddDistributedSqlServerCache(_ => { }));
+        }
     }
 }


### PR DESCRIPTION
Previously the AddCaching method did this. It is also common in other builder methods like this. It doesn't do any harm for those that don't want to chain and allows cleaner code with fewer variable declarations for those that do.