### PR TITLE
Adding ambient link scopes chain implicitly

### DIFF
--- a/samples/MemoryCacheSample/Program.cs
+++ b/samples/MemoryCacheSample/Program.cs
@@ -101,7 +101,6 @@ namespace MemoryCacheSample
 
                 // expire this entry if the entry with key "key1" expires.
                 cache.Set("key2", "value2", new MemoryCacheEntryOptions()
-                    .AddEntryLink(link)
                     .RegisterPostEvictionCallback(
                     (echoKey, value, reason, substate) =>
                     {

--- a/src/Microsoft.Extensions.Caching.Abstractions/MemoryCacheEntryExtensions.cs
+++ b/src/Microsoft.Extensions.Caching.Abstractions/MemoryCacheEntryExtensions.cs
@@ -119,24 +119,5 @@ namespace Microsoft.Extensions.Caching.Memory
             });
             return options;
         }
-
-        /// <summary>
-        /// Adds inherited token and absolute expiration information.
-        /// </summary>
-        /// <param name="options"></param>
-        /// <param name="link"></param>
-        public static MemoryCacheEntryOptions AddEntryLink(this MemoryCacheEntryOptions options, IEntryLink link)
-        {
-            foreach (var expirationToken in link.ExpirationTokens)
-            {
-                options.AddExpirationToken(expirationToken);
-            }
-
-            if (link.AbsoluteExpiration.HasValue)
-            {
-                options.SetAbsoluteExpiration(link.AbsoluteExpiration.Value);
-            }
-            return options;
-        }
     }
 }


### PR DESCRIPTION
- Any call to `Set` will automatically be enlisted in the ambient entry link.
- Options are dispatched to all parent entry links when an entry is added such that they can be shared.
- A `CacheEntry` can now be associated to a `CacheEntlyLink` so that checking for expiration will also check the expiration (time and tokens) on the entry link's tokens.
- Unit tests ensure that sibling scopes are not affected by expired tokens.