### PR TITLE
Bump tools version

### DIFF
--- a/src/Microsoft.Extensions.Caching.SqlConfig.Tools/project.json
+++ b/src/Microsoft.Extensions.Caching.SqlConfig.Tools/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-preview3-*",
+  "version": "1.0.0-preview4-*",
   "dependencies": {
     "Microsoft.Extensions.CommandLineUtils": "1.1.0-*",
     "Microsoft.Extensions.Logging": "1.1.0-*",


### PR DESCRIPTION
Merges to dev. This will help us avoid possible confusion between versions built from `dev` and `rel/tools-1.0.0-preview3` (cref #227 ) 

cc @muratg @pranavkm 