### PR TITLE
Ensure Redis and SqlServer cache operations silently fail

### DIFF
--- a/src/Microsoft.Extensions.Caching.Redis/RedisCacheLoggingExtensions.cs
+++ b/src/Microsoft.Extensions.Caching.Redis/RedisCacheLoggingExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Caching.Redis
+{
+    internal static class RedisCacheLoggingExtensions
+    {
+        private static readonly Action<ILogger, Exception> _suppressedCacheException;
+
+        static RedisCacheLoggingExtensions()
+        {
+            _suppressedCacheException = LoggerMessage.Define(
+                LogLevel.Debug,
+                0,
+                "An exception during cache operation was suppressed");
+        }
+
+        public static void ExceptionSuppressed(this ILogger logger, Exception ex)
+        {
+            _suppressedCacheException(logger, ex);
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Caching.Redis/project.json
+++ b/src/Microsoft.Extensions.Caching.Redis/project.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "Microsoft.Extensions.Caching.Abstractions": "1.1.0-*",
+    "Microsoft.Extensions.Logging.Abstractions": "1.1.0-*",
     "Microsoft.Extensions.Options": "1.1.0-*",
     "NETStandard.Library": "1.6.1-*",
     "StackExchange.Redis.StrongName": "1.1.605"

--- a/src/Microsoft.Extensions.Caching.SqlServer/SqlServerCacheLoggingExtensions.cs
+++ b/src/Microsoft.Extensions.Caching.SqlServer/SqlServerCacheLoggingExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Caching.SqlServer
+{
+    internal static class SqlServerCacheLoggingExtensions
+    {
+        private static readonly Action<ILogger, Exception> _suppressedCacheException;
+
+        static SqlServerCacheLoggingExtensions()
+        {
+            _suppressedCacheException = LoggerMessage.Define(
+                LogLevel.Debug,
+                0,
+                "An exception during cache operation was suppressed");
+        }
+
+        public static void ExceptionSuppressed(this ILogger logger, Exception ex)
+        {
+            _suppressedCacheException(logger, ex);
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Caching.SqlServer/project.json
+++ b/src/Microsoft.Extensions.Caching.SqlServer/project.json
@@ -2,6 +2,7 @@
   "version": "1.1.0-alpha1-*",
   "dependencies": {
     "Microsoft.Extensions.Caching.Abstractions": "1.1.0-*",
+    "Microsoft.Extensions.Logging.Abstractions": "1.1.0-*",
     "Microsoft.Extensions.Options": "1.1.0-*",
     "NETStandard.Library": "1.6.1-*"
   },


### PR DESCRIPTION
Resolve #193 

Per our design discussion, this adds top-level catches for all exceptions with optional logging for suppressed exceptions.

NB: introduces dependency on logging abstractions.

cc @JunTaoLuo @Tratcher @pakrym 