### PR TITLE
Interlock.exchange to handle locking around the connection creation

### DIFF
--- a/src/Microsoft.Extensions.Caching.Redis/RedisCache.cs
+++ b/src/Microsoft.Extensions.Caching.Redis/RedisCache.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Options;
@@ -157,7 +158,8 @@ namespace Microsoft.Extensions.Caching.Redis
         {
             if (_connection == null)
             {
-                _connection = ConnectionMultiplexer.Connect(_options.Configuration);
+               // _connection = ConnectionMultiplexer.Connect(_options.Configuration);
+                Interlocked.Exchange(ref _connection, ConnectionMultiplexer.Connect(_options.Configuration));
                 _cache = _connection.GetDatabase();
             }
         }


### PR DESCRIPTION
There was no locking around the connection creation hence added Interlock.exchange to handle this.