### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/test/Microsoft.Extensions.Caching.Memory.Tests/MemoryCacheSetAndRemoveTests.cs
+++ b/test/Microsoft.Extensions.Caching.Memory.Tests/MemoryCacheSetAndRemoveTests.cs
@@ -461,7 +461,7 @@ namespace Microsoft.Extensions.Caching.Memory
             Task.WaitAll(task0, task1, task2, task3);
         }
 
-#if NET451
+#if NET452
         private static void DomainFunc()
         {
             var expected = 20;

--- a/test/Microsoft.Extensions.Caching.Memory.Tests/Microsoft.Extensions.Caching.Memory.Tests.csproj
+++ b/test/Microsoft.Extensions.Caching.Memory.Tests/Microsoft.Extensions.Caching.Memory.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Extensions.Caching.Redis.Tests/Microsoft.Extensions.Caching.Redis.Tests.csproj
+++ b/test/Microsoft.Extensions.Caching.Redis.Tests/Microsoft.Extensions.Caching.Redis.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Extensions.Caching.SqlServer.Tests/Microsoft.Extensions.Caching.SqlServer.Tests.csproj
+++ b/test/Microsoft.Extensions.Caching.SqlServer.Tests/Microsoft.Extensions.Caching.SqlServer.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows