### PR TITLE
Disable API Check in project that breaks the tool

### DIFF
--- a/src/Microsoft.Extensions.Caching.SqlServer/Microsoft.Extensions.Caching.SqlServer.csproj
+++ b/src/Microsoft.Extensions.Caching.SqlServer/Microsoft.Extensions.Caching.SqlServer.csproj
@@ -9,7 +9,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>cache;distributedcache;sqlserver</PackageTags>
 
-    <!-- TODO File bug to fix ApiCheck so it can handle this project before this goes in. -->
+    <!-- Temporary workaround for API Check crash that is part of aspnet/BuildTools#201. -->
     <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
 

--- a/src/Microsoft.Extensions.Caching.SqlServer/Microsoft.Extensions.Caching.SqlServer.csproj
+++ b/src/Microsoft.Extensions.Caching.SqlServer/Microsoft.Extensions.Caching.SqlServer.csproj
@@ -8,6 +8,9 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>cache;distributedcache;sqlserver</PackageTags>
+
+    <!-- TODO File bug to fix ApiCheck so it can handle this project before this goes in. -->
+    <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- hits a `FileNotFoundException` because System.Data.SqlClient package lacks runtime assemblies for .NET Standard 1.2