### PR TITLE
Update doc comments

### DIFF
--- a/src/Microsoft.Extensions.Caching.Memory/MemoryCacheOptions.cs
+++ b/src/Microsoft.Extensions.Caching.Memory/MemoryCacheOptions.cs
@@ -14,12 +14,12 @@ namespace Microsoft.Extensions.Caching.Memory
 
         public ISystemClock Clock { get; set; }
 
-        /// <summary>
-        /// Gets or sets the minimum length of time between successive scans for expired items.
-        /// </summary>
         [Obsolete("This is obsolete and will be removed in a future version.")]
         public bool CompactOnMemoryPressure { get; set; }
 
+        /// <summary>
+        /// Gets or sets the minimum length of time between successive scans for expired items.
+        /// </summary>
         public TimeSpan ExpirationScanFrequency { get; set; } = TimeSpan.FromMinutes(1);
 
         /// <summary>


### PR DESCRIPTION
I noticed this as I was responding to an issue. We should match the doc comment to the actual property it is describing. Also, a time duration between successive events should be called a period and frequency = 1/period. Calling the property ExpirationScanFrequency is not technically accurate.