### PR TITLE
Allow ConfigurationOptions to be passed to the ConnectionMultiplexer

### DIFF
--- a/src/Microsoft.Extensions.Caching.Redis/RedisCache.cs
+++ b/src/Microsoft.Extensions.Caching.Redis/RedisCache.cs
@@ -174,7 +174,14 @@ namespace Microsoft.Extensions.Caching.Redis
             {
                 if (_cache == null)
                 {
-                    _connection = ConnectionMultiplexer.Connect(_options.Configuration);
+                    if (_options.ConfigurationOptions != null)
+                    {
+                        _connection = ConnectionMultiplexer.Connect(_options.ConfigurationOptions);
+                    }
+                    else
+                    {
+                        _connection = ConnectionMultiplexer.Connect(_options.Configuration);                        
+                    }
                     _cache = _connection.GetDatabase();
                 }
             }
@@ -198,7 +205,15 @@ namespace Microsoft.Extensions.Caching.Redis
             {
                 if (_cache == null)
                 {
-                    _connection = await ConnectionMultiplexer.ConnectAsync(_options.Configuration);
+                    if (_options.ConfigurationOptions != null)
+                    {
+                        _connection = await ConnectionMultiplexer.ConnectAsync(_options.ConfigurationOptions);
+                    }
+                    else
+                    {
+                        _connection = await ConnectionMultiplexer.ConnectAsync(_options.Configuration);                  
+                    }
+                    
                     _cache = _connection.GetDatabase();
                 }
             }

--- a/src/Microsoft.Extensions.Caching.Redis/RedisCacheOptions.cs
+++ b/src/Microsoft.Extensions.Caching.Redis/RedisCacheOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Extensions.Options;
+using StackExchange.Redis;
 
 namespace Microsoft.Extensions.Caching.Redis
 {
@@ -14,6 +15,12 @@ namespace Microsoft.Extensions.Caching.Redis
         /// The configuration used to connect to Redis.
         /// </summary>
         public string Configuration { get; set; }
+        
+        /// <summary>
+        /// The configuration used to connect to Redis.
+        /// This is preferred over Configuration.
+        /// </summary>
+        public ConfigurationOptions ConfigurationOptions { get; set; }
 
         /// <summary>
         /// The Redis instance name.


### PR DESCRIPTION
Summary of the changes:
 - Adds ConfigurationOptions to RedisCacheOptions
 - Passes either ConfigurationOptions or Configuration to ConnectionMultiplexer.

This allows you to set options in the ConnectionMultiplexer that you cannot when using the connection string, such as RemoteCertificateValidationCallback