### PR TITLE
Removed unused variables fetched from the database

### DIFF
--- a/src/Microsoft.Extensions.Caching.SqlServer/Columns.cs
+++ b/src/Microsoft.Extensions.Caching.SqlServer/Columns.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
             public const int SlidingExpirationInSecondsIndex = 2;
             public const int AbsoluteExpirationIndex = 3;
             public const int CacheItemValueIndex = 4;
+            public const int CacheItemOnlyValueIndex = 0;
         }
     }
 }

--- a/src/Microsoft.Extensions.Caching.SqlServer/DatabaseOperations.cs
+++ b/src/Microsoft.Extensions.Caching.SqlServer/DatabaseOperations.cs
@@ -209,9 +209,6 @@ namespace Microsoft.Extensions.Caching.SqlServer
             }
 
             byte[] value = null;
-            TimeSpan? slidingExpiration = null;
-            DateTimeOffset? absoluteExpiration = null;
-            DateTimeOffset expirationTime;
             using (var connection = new SqlConnection(ConnectionString))
             {
                 var command = new SqlCommand(query, connection);
@@ -226,25 +223,9 @@ namespace Microsoft.Extensions.Caching.SqlServer
 
                 if (reader.Read())
                 {
-                    var id = reader.GetFieldValue<string>(Columns.Indexes.CacheItemIdIndex);
-
-                    expirationTime = reader.GetFieldValue<DateTimeOffset>(Columns.Indexes.ExpiresAtTimeIndex);
-
-                    if (!reader.IsDBNull(Columns.Indexes.SlidingExpirationInSecondsIndex))
-                    {
-                        slidingExpiration = TimeSpan.FromSeconds(
-                            reader.GetFieldValue<long>(Columns.Indexes.SlidingExpirationInSecondsIndex));
-                    }
-
-                    if (!reader.IsDBNull(Columns.Indexes.AbsoluteExpirationIndex))
-                    {
-                        absoluteExpiration = reader.GetFieldValue<DateTimeOffset>(
-                            Columns.Indexes.AbsoluteExpirationIndex);
-                    }
-
                     if (includeValue)
                     {
-                        value = reader.GetFieldValue<byte[]>(Columns.Indexes.CacheItemValueIndex);
+                        value = reader.GetFieldValue<byte[]>(Columns.Indexes.CacheItemOnlyValueIndex);
                     }
                 }
                 else
@@ -273,9 +254,6 @@ namespace Microsoft.Extensions.Caching.SqlServer
             }
 
             byte[] value = null;
-            TimeSpan? slidingExpiration = null;
-            DateTimeOffset? absoluteExpiration = null;
-            DateTimeOffset expirationTime;
             using (var connection = new SqlConnection(ConnectionString))
             {
                 var command = new SqlCommand(query, connection);
@@ -291,27 +269,9 @@ namespace Microsoft.Extensions.Caching.SqlServer
 
                 if (await reader.ReadAsync(token))
                 {
-                    var id = await reader.GetFieldValueAsync<string>(Columns.Indexes.CacheItemIdIndex, token);
-
-                    expirationTime = await reader.GetFieldValueAsync<DateTimeOffset>(
-                        Columns.Indexes.ExpiresAtTimeIndex, token);
-
-                    if (!await reader.IsDBNullAsync(Columns.Indexes.SlidingExpirationInSecondsIndex, token))
-                    {
-                        slidingExpiration = TimeSpan.FromSeconds(
-                            await reader.GetFieldValueAsync<long>(Columns.Indexes.SlidingExpirationInSecondsIndex, token));
-                    }
-
-                    if (!await reader.IsDBNullAsync(Columns.Indexes.AbsoluteExpirationIndex, token))
-                    {
-                        absoluteExpiration = await reader.GetFieldValueAsync<DateTimeOffset>(
-                            Columns.Indexes.AbsoluteExpirationIndex,
-                            token);
-                    }
-
                     if (includeValue)
                     {
-                        value = await reader.GetFieldValueAsync<byte[]>(Columns.Indexes.CacheItemValueIndex, token);
+                        value = await reader.GetFieldValueAsync<byte[]>(Columns.Indexes.CacheItemOnlyValueIndex, token);
                     }
                 }
                 else

--- a/src/Microsoft.Extensions.Caching.SqlServer/MonoDatabaseOperations.cs
+++ b/src/Microsoft.Extensions.Caching.SqlServer/MonoDatabaseOperations.cs
@@ -34,9 +34,6 @@ namespace Microsoft.Extensions.Caching.SqlServer
             }
 
             byte[] value = null;
-            TimeSpan? slidingExpiration = null;
-            DateTimeOffset? absoluteExpiration = null;
-            DateTimeOffset expirationTime;
             using (var connection = new SqlConnection(ConnectionString))
             {
                 var command = new SqlCommand(query, connection);
@@ -50,25 +47,9 @@ namespace Microsoft.Extensions.Caching.SqlServer
 
                 if (reader.Read())
                 {
-                    var id = reader.GetString(Columns.Indexes.CacheItemIdIndex);
-
-                    expirationTime = DateTimeOffset.Parse(reader[Columns.Indexes.ExpiresAtTimeIndex].ToString());
-
-                    if (!reader.IsDBNull(Columns.Indexes.SlidingExpirationInSecondsIndex))
-                    {
-                        slidingExpiration = TimeSpan.FromSeconds(
-                            reader.GetInt64(Columns.Indexes.SlidingExpirationInSecondsIndex));
-                    }
-
-                    if (!reader.IsDBNull(Columns.Indexes.AbsoluteExpirationIndex))
-                    {
-                        absoluteExpiration = DateTimeOffset.Parse(
-                            reader[Columns.Indexes.AbsoluteExpirationIndex].ToString());
-                    }
-
                     if (includeValue)
                     {
-                        value = (byte[])reader[Columns.Indexes.CacheItemValueIndex];
+                        value = (byte[])reader[Columns.Indexes.CacheItemOnlyValueIndex];
                     }
                 }
                 else
@@ -97,9 +78,6 @@ namespace Microsoft.Extensions.Caching.SqlServer
             }
 
             byte[] value = null;
-            TimeSpan? slidingExpiration = null;
-            DateTimeOffset? absoluteExpiration = null;
-            DateTimeOffset expirationTime;
             using (var connection = new SqlConnection(ConnectionString))
             {
                 var command = new SqlCommand(SqlQueries.GetCacheItem, connection);
@@ -115,25 +93,9 @@ namespace Microsoft.Extensions.Caching.SqlServer
 
                 if (await reader.ReadAsync(token))
                 {
-                    var id = reader.GetString(Columns.Indexes.CacheItemIdIndex);
-
-                    expirationTime = DateTimeOffset.Parse(reader[Columns.Indexes.ExpiresAtTimeIndex].ToString());
-
-                    if (!await reader.IsDBNullAsync(Columns.Indexes.SlidingExpirationInSecondsIndex, token))
-                    {
-                        slidingExpiration = TimeSpan.FromSeconds(
-                            Convert.ToInt64(reader[Columns.Indexes.SlidingExpirationInSecondsIndex].ToString()));
-                    }
-
-                    if (!await reader.IsDBNullAsync(Columns.Indexes.AbsoluteExpirationIndex, token))
-                    {
-                        absoluteExpiration = DateTimeOffset.Parse(
-                            reader[Columns.Indexes.AbsoluteExpirationIndex].ToString());
-                    }
-
                     if (includeValue)
                     {
-                        value = (byte[])reader[Columns.Indexes.CacheItemValueIndex];
+                        value = (byte[])reader[Columns.Indexes.CacheItemOnlyValueIndex];
                     }
                 }
                 else

--- a/src/Microsoft.Extensions.Caching.SqlServer/SqlQueries.cs
+++ b/src/Microsoft.Extensions.Caching.SqlServer/SqlQueries.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
         "AND (AbsoluteExpiration IS NULL OR AbsoluteExpiration <> ExpiresAtTime) ;";
 
         private const string GetCacheItemFormat =
-            "SELECT Id, ExpiresAtTime, SlidingExpirationInSeconds, AbsoluteExpiration, Value " +
+            "SELECT Value " +
             "FROM {0} WHERE Id = @Id AND @UtcNow <= ExpiresAtTime;";
 
         private const string SetCacheItemFormat =


### PR DESCRIPTION
There are variables fetched from the database but never used. Apart from the cost of fetching the value for those variables from the database there is an added cost converting the values.

Also, if those values are removed, the query shouldn't contain the columns that are not needed, because the database server will process and send all variables specified in the query.

I guess this is due some legacy code. The fetched values (AbsoluteExpiration, SlidingExpiration and expirationTime) were computed in process, but now the query string contains an `update` and a `select`, so those values are computed directly in the database (which is a more efficient and better approach).

This pull request removes the fetch and conversion of these variables, and cleans the columns in the query in order to fetch the only needed data.

Following the [instructions written in this point of the contributing guide](https://github.com/aspnet/Home/blob/dev/CONTRIBUTING.md#contributing-code-and-content) for a small fix is possible to open directly a pull request, but if you consider more appropriate to open an issue for this I can do it, up to you ;)