### PR TITLE
Add logging for capacity tests

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -10,6 +10,8 @@
     <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>3.0.0-alpha1-10584</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
     <MicrosoftExtensionsDependencyInjectionPackageVersion>3.0.0-alpha1-10584</MicrosoftExtensionsDependencyInjectionPackageVersion>
     <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>3.0.0-alpha1-10584</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>3.0.0-alpha1-10584</MicrosoftExtensionsLoggingPackageVersion>
+    <MicrosoftExtensionsLoggingTestingPackageVersion>3.0.0-alpha1-10584</MicrosoftExtensionsLoggingTestingPackageVersion>
     <MicrosoftExtensionsOptionsPackageVersion>3.0.0-alpha1-10584</MicrosoftExtensionsOptionsPackageVersion>
     <MicrosoftExtensionsPrimitivesPackageVersion>3.0.0-alpha1-10584</MicrosoftExtensionsPrimitivesPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>

--- a/src/Microsoft.Extensions.Caching.Memory/Microsoft.Extensions.Caching.Memory.csproj
+++ b/src/Microsoft.Extensions.Caching.Memory/Microsoft.Extensions.Caching.Memory.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
   </ItemGroup>
 

--- a/test/Microsoft.Extensions.Caching.Memory.Tests/CapacityTests.cs
+++ b/test/Microsoft.Extensions.Caching.Memory.Tests/CapacityTests.cs
@@ -6,11 +6,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory.Infrastructure;
 using Microsoft.Extensions.Internal;
+using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
 namespace Microsoft.Extensions.Caching.Memory
 {
-    public class CapacityTests
+    public class CapacityTests : LoggedTestBase
     {
         [Fact]
         public void MemoryDistributedCacheOptionsDefaultsTo200MBSizeLimit()
@@ -116,6 +117,8 @@ namespace Microsoft.Extensions.Caching.Memory
             {
                 SizeLimit = long.MaxValue
             });
+
+            cache.Logger = Logger;
 
             var entryOptions = new MemoryCacheEntryOptions { Size = long.MaxValue };
             var sem = new SemaphoreSlim(0, 1);

--- a/test/Microsoft.Extensions.Caching.Memory.Tests/Microsoft.Extensions.Caching.Memory.Tests.csproj
+++ b/test/Microsoft.Extensions.Caching.Memory.Tests/Microsoft.Extensions.Caching.Memory.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(MicrosoftExtensionsLoggingTestingPackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adding logging to test out my theory on https://github.com/aspnet/Caching/issues/429. I opted for an internal property used for tests since it's simple. However, this wouldn't help with https://github.com/aspnet/Caching/issues/261.